### PR TITLE
Bundle action dist and document release steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+!/packages/action/dist/
 .base-lint-report/
 .DS_Store
 *.log

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -13,3 +13,11 @@ GitHub Action wrapper for the `base-lint` CLI. See [`packages/cli`](../cli) for 
     comment: true
     checks: true
 ```
+
+## Release checklist
+
+Before tagging a new release:
+
+1. Run `npm run build -w packages/action` to regenerate the bundled `dist/` output referenced by [`action.yml`](./action.yml).
+2. Commit any changes under `packages/action/dist` so the published tag always includes the compiled JavaScript.
+3. Verify CI passes to ensure the action bundle remains in sync with the TypeScript sources.

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -1,0 +1,210 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var index_exports = {};
+__export(index_exports, {
+  runBaseLint: () => runBaseLint
+});
+module.exports = __toCommonJS(index_exports);
+
+// virtual:@actions/core
+var core_exports = {};
+__export(core_exports, {
+  error: () => error,
+  getBooleanInput: () => getBooleanInput,
+  getInput: () => getInput,
+  info: () => info,
+  setFailed: () => setFailed,
+  warning: () => warning
+});
+var INPUT_PREFIX = "INPUT_";
+function toEnvKey(name) {
+  return `${INPUT_PREFIX}${name.replace(/ /g, "_")}`.toUpperCase();
+}
+function readInput(name, options = {}) {
+  const envKey = toEnvKey(name);
+  const raw = process.env[envKey] ?? "";
+  const trimWhitespace = options.trimWhitespace ?? true;
+  return trimWhitespace ? raw.trim() : raw;
+}
+function getInput(name, options) {
+  const value = readInput(name, options);
+  if (!value && options?.required) {
+    throw new Error(`Input required and not supplied: ${name}`);
+  }
+  return value;
+}
+function getBooleanInput(name, options) {
+  const normalized = getInput(name, { ...options, trimWhitespace: true }).toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (["true", "1"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0"].includes(normalized)) {
+    return false;
+  }
+  throw new TypeError(`Input does not meet boolean requirements: ${name}`);
+}
+function info(message) {
+  console.log(message);
+}
+function warning(message) {
+  console.warn(message);
+}
+function error(message) {
+  console.error(message);
+}
+function setFailed(message) {
+  const output = message instanceof Error ? message.message : String(message);
+  console.error(output);
+  process.exitCode = 1;
+}
+
+// virtual:@actions/github
+var import_fs = __toESM(require("fs"));
+function loadEventPayload() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath) {
+    try {
+      const file = import_fs.default.readFileSync(eventPath, "utf8");
+      return JSON.parse(file);
+    } catch (error2) {
+      console.warn("Failed to read GitHub event payload:", error2);
+    }
+  }
+  const rawPayload = process.env.GITHUB_EVENT_PAYLOAD;
+  if (rawPayload) {
+    try {
+      return JSON.parse(rawPayload);
+    } catch (error2) {
+      console.warn("Failed to parse GITHUB_EVENT_PAYLOAD:", error2);
+    }
+  }
+  return {};
+}
+var context = {
+  payload: loadEventPayload()
+};
+
+// src/index.ts
+var import_child_process = require("child_process");
+var import_path = __toESM(require("path"));
+var import_url = require("url");
+var import_meta = {};
+async function main() {
+  try {
+    const mode = getInput("mode") || "diff";
+    const maxLimited = getInput("max-limited") || "0";
+    const treatNewlyAs = getInput("treat-newly-as") || "warn";
+    const shouldComment = getBooleanInput("comment");
+    const shouldAnnotate = getBooleanInput("checks");
+    const reportDir = ".base-lint-report";
+    const reportJson = import_path.default.join(reportDir, "report.json");
+    const reportMd = import_path.default.join(reportDir, "report.md");
+    await runBaseLint(["scan", "--mode", mode, "--out", reportDir, "--treat-newly", treatNewlyAs]);
+    let enforcementFailed = false;
+    try {
+      const enforceArgs = ["enforce", "--input", reportJson, "--max-limited", maxLimited];
+      if (treatNewlyAs === "error") {
+        enforceArgs.push("--fail-on-warn");
+      }
+      await runBaseLint(enforceArgs);
+    } catch (error2) {
+      enforcementFailed = true;
+      error(error2.message);
+    }
+    const pr = context.payload.pull_request;
+    const isFork = Boolean(
+      pr?.head?.repo?.full_name && pr?.base?.repo?.full_name && pr.head.repo.full_name !== pr.base.repo.full_name
+    );
+    if (shouldAnnotate && !isFork) {
+      try {
+        await runBaseLint(["annotate", "--input", reportJson]);
+      } catch (error2) {
+        warning(`Failed to publish annotations: ${error2.message}`);
+      }
+    } else if (shouldAnnotate) {
+      info("Skipping annotations for forked pull request.");
+    }
+    if (shouldComment && pr && !isFork) {
+      try {
+        await runBaseLint(["comment", "--input", reportMd]);
+      } catch (error2) {
+        warning(`Failed to post sticky comment: ${error2.message}`);
+      }
+    } else if (shouldComment && isFork) {
+      info("Skipping sticky comment for forked pull request.");
+    } else if (shouldComment && !pr) {
+      info("Skipping sticky comment: no pull request context available.");
+    }
+    if (enforcementFailed) {
+      setFailed("Baseline policy violated. See report for details.");
+    }
+  } catch (error2) {
+    setFailed(error2.message);
+  }
+}
+async function runBaseLint(args, deps = {}) {
+  const coreApi = deps.core ?? core_exports;
+  const spawnFn = deps.spawn ?? import_child_process.spawn;
+  coreApi.info(`Running base-lint ${args.join(" ")}`);
+  await new Promise((resolve, reject) => {
+    const proc = spawnFn("npx", ["--yes", "base-lint", ...args], {
+      stdio: "inherit"
+    });
+    proc.on("error", (error2) => reject(error2));
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`base-lint ${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+var entryFile = process.argv[1];
+if (entryFile) {
+  const entryUrl = (0, import_url.pathToFileURL)(entryFile).href;
+  let isDirectEsmExecution = false;
+  try {
+    isDirectEsmExecution = entryUrl === import_meta.url;
+  } catch {
+  }
+  const isDirectCjsExecution = typeof require !== "undefined" && require.main === module;
+  if (isDirectEsmExecution || isDirectCjsExecution) {
+    void main();
+  }
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  runBaseLint
+});

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -13,7 +13,7 @@
     "vitest": "../../tests/mocks/vitest.js"
   },
   "scripts": {
-    "build": "ncc build src/index.ts -o dist",
+    "build": "node ../../scripts/build-action.mjs",
     "prepare": "npm run build"
   },
   "dependencies": {
@@ -21,7 +21,6 @@
     "@actions/github": "^5.1.1"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.38.1",
     "typescript": "^5.4.2"
   }
 }

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -93,7 +93,15 @@ export async function runBaseLint(args: string[], deps: RunBaseLintDeps = {}): P
 const entryFile = process.argv[1];
 if (entryFile) {
   const entryUrl = pathToFileURL(entryFile).href;
-  if (entryUrl === import.meta.url) {
+  let isDirectEsmExecution = false;
+  try {
+    isDirectEsmExecution = entryUrl === import.meta.url;
+  } catch {
+    // `import.meta` is unavailable in CommonJS builds.
+  }
+
+  const isDirectCjsExecution = typeof require !== 'undefined' && require.main === module;
+  if (isDirectEsmExecution || isDirectCjsExecution) {
     void main();
   }
 }

--- a/packages/action/src/types/actions.d.ts
+++ b/packages/action/src/types/actions.d.ts
@@ -1,0 +1,19 @@
+declare module '@actions/core' {
+  export function getInput(name: string, options?: { required?: boolean; trimWhitespace?: boolean }): string;
+  export function getBooleanInput(name: string, options?: { required?: boolean }): boolean;
+  export function info(message: string): void;
+  export function warning(message: string): void;
+  export function error(message: string): void;
+  export function setFailed(message: string | Error): void;
+}
+
+declare module '@actions/github' {
+  export const context: {
+    payload: {
+      pull_request?: {
+        head?: { repo?: { full_name?: string } };
+        base?: { repo?: { full_name?: string } };
+      };
+    };
+  };
+}

--- a/scripts/build-action.mjs
+++ b/scripts/build-action.mjs
@@ -1,0 +1,43 @@
+import { build } from 'esbuild';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs/promises';
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptsDir, '..');
+const packageDir = path.join(rootDir, 'packages', 'action');
+const distDir = path.join(packageDir, 'dist');
+const templatesDir = path.join(scriptsDir, 'templates');
+
+const coreModuleSource = await fs.readFile(path.join(templatesDir, 'actions-core.ts'), 'utf8');
+const githubModuleSource = await fs.readFile(path.join(templatesDir, 'actions-github.ts'), 'utf8');
+
+await fs.rm(distDir, { recursive: true, force: true });
+await fs.mkdir(distDir, { recursive: true });
+
+await build({
+  entryPoints: [path.join(packageDir, 'src', 'index.ts')],
+  bundle: true,
+  platform: 'node',
+  target: ['node18'],
+  outfile: path.join(distDir, 'index.js'),
+  sourcemap: false,
+  plugins: [
+    {
+      name: 'virtual-actions-modules',
+      setup(build) {
+        build.onResolve({ filter: /^@actions\/core$/ }, () => ({ path: '@actions/core', namespace: 'virtual' }));
+        build.onResolve({ filter: /^@actions\/github$/ }, () => ({ path: '@actions/github', namespace: 'virtual' }));
+        build.onLoad({ filter: /^@actions\/core$/, namespace: 'virtual' }, () => ({
+          contents: coreModuleSource,
+          loader: 'ts',
+        }));
+        build.onLoad({ filter: /^@actions\/github$/, namespace: 'virtual' }, () => ({
+          contents: githubModuleSource,
+          loader: 'ts',
+        }));
+      },
+    },
+  ],
+  logLevel: 'info',
+});

--- a/scripts/templates/actions-core.ts
+++ b/scripts/templates/actions-core.ts
@@ -1,0 +1,61 @@
+const INPUT_PREFIX = 'INPUT_';
+
+type GetInputOptions = {
+  required?: boolean;
+  trimWhitespace?: boolean;
+};
+
+type GetBooleanInputOptions = {
+  required?: boolean;
+};
+
+function toEnvKey(name: string): string {
+  return `${INPUT_PREFIX}${name.replace(/ /g, '_')}`.toUpperCase();
+}
+
+function readInput(name: string, options: GetInputOptions = {}): string {
+  const envKey = toEnvKey(name);
+  const raw = process.env[envKey] ?? '';
+  const trimWhitespace = options.trimWhitespace ?? true;
+  return trimWhitespace ? raw.trim() : raw;
+}
+
+export function getInput(name: string, options?: GetInputOptions): string {
+  const value = readInput(name, options);
+  if (!value && options?.required) {
+    throw new Error(`Input required and not supplied: ${name}`);
+  }
+  return value;
+}
+
+export function getBooleanInput(name: string, options?: GetBooleanInputOptions): boolean {
+  const normalized = getInput(name, { ...options, trimWhitespace: true }).toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (['true', '1'].includes(normalized)) {
+    return true;
+  }
+  if (['false', '0'].includes(normalized)) {
+    return false;
+  }
+  throw new TypeError(`Input does not meet boolean requirements: ${name}`);
+}
+
+export function info(message: string): void {
+  console.log(message);
+}
+
+export function warning(message: string): void {
+  console.warn(message);
+}
+
+export function error(message: string): void {
+  console.error(message);
+}
+
+export function setFailed(message: string | Error): void {
+  const output = message instanceof Error ? message.message : String(message);
+  console.error(output);
+  process.exitCode = 1;
+}

--- a/scripts/templates/actions-github.ts
+++ b/scripts/templates/actions-github.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+
+function loadEventPayload(): Record<string, unknown> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath) {
+    try {
+      const file = fs.readFileSync(eventPath, 'utf8');
+      return JSON.parse(file) as Record<string, unknown>;
+    } catch (error) {
+      console.warn('Failed to read GitHub event payload:', error);
+    }
+  }
+
+  const rawPayload = process.env.GITHUB_EVENT_PAYLOAD;
+  if (rawPayload) {
+    try {
+      return JSON.parse(rawPayload) as Record<string, unknown>;
+    } catch (error) {
+      console.warn('Failed to parse GITHUB_EVENT_PAYLOAD:', error);
+    }
+  }
+
+  return {};
+}
+
+export const context = {
+  payload: loadEventPayload() as {
+    pull_request?: {
+      head?: { repo?: { full_name?: string } };
+      base?: { repo?: { full_name?: string } };
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- allow committing the action bundle by updating the ignore list and replacing the build script with an offline esbuild pipeline
- add templates that provide minimal @actions/core and @actions/github implementations and check in the generated dist output
- document a release checklist that requires rebuilding and committing the action bundle before tagging

## Testing
- npm run build -w packages/action
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d61c0f2ae883239c07f5fa0f39b768