### PR TITLE
docs: refresh testing, build, and release guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,18 +100,38 @@ npm install
 
 Useful commands while developing:
 
-- `npm run build` – Compile the CLI and GitHub Action packages.
-- `npm run test:unit` – Execute the mock-focused unit test suite with coverage enforcement.
+- `npm run build` – Compile both packages (`packages/cli` and `packages/action`).
+- `npm run build -w packages/cli` – Rebuild just the CLI bundle (emits `packages/cli/dist/index.js`).
+- `npm run build -w packages/action` – Rebuild just the GitHub Action bundle (emits `packages/action/dist/index.js`).
+- `npm run test:unit` – Execute the Node Test Runner-based unit suite with coverage enforcement.
 - `npm run test:e2e` – Run the end-to-end scenarios against temporary workspaces.
+- `npm test` – Run unit + e2e suites sequentially (same as `npm run coverage`).
 
 ## Testing & Coverage
 
-All test runners are implemented as Node scripts so CI can execute them without additional tooling.
+All test runners are implemented as Node scripts so CI can execute them without additional tooling. After the Vitest suites were retired, the repository relies entirely on the Node Test Runner and mocks under `tests/mocks`.
 
-- `npm test` – Runs the full suite (unit and e2e) sequentially and fails if global coverage drops below 80%.
-- `npm run coverage` – Alias for `npm test`, handy when you only need the coverage report.
+- `npm test` / `npm run coverage` – Runs the full suite (unit and e2e) sequentially and fails if global coverage drops below 80%.
+- `npm run test:unit` – Targets the fast unit suite driven by the Node Test Runner.
+- `npm run test:e2e` – Executes the slower end-to-end coverage that shells out to the real CLI.
 
 The repository favors mock-heavy unit tests to keep feedback loops tight. When adding new specs, prefer mocking external services, filesystem state, and process execution unless a scenario explicitly requires real integration behavior. End-to-end tests should rely on the provided helpers in `tests/e2e` to set up isolated workspaces and clean up temporary files.
+
+## Publishing
+
+### Release the CLI to npm
+
+1. Update the version in `packages/cli/package.json` (and changelog, if applicable).
+2. Run `npm run build -w packages/cli` to regenerate `packages/cli/dist/index.js` (includes the executable shebang).
+3. From the repo root, publish with `npm publish --workspace packages/cli --access public`.
+4. Tag the release (`git tag cli-vX.Y.Z && git push origin cli-vX.Y.Z`).
+
+### Release the GitHub Action to the Marketplace
+
+1. Update the version in `packages/action/package.json` and `packages/action/action.yml`.
+2. Rebuild the bundle with `npm run build -w packages/action` and commit the resulting `packages/action/dist` output.
+3. Create a Git tag (`git tag action-vX.Y.Z && git push origin action-vX.Y.Z`).
+4. Draft a GitHub release that points to the new tag—Marketplace listings pick up the bundled `dist/` assets automatically.
 
 ## Security & Privacy
 


### PR DESCRIPTION
## Summary
- expand the development command cheatsheet with the new per-package build scripts and consolidated test runner guidance
- document that the project now relies on the Node Test Runner after removing the legacy Vitest suites
- add step-by-step instructions for publishing the CLI to npm and the GitHub Action to the Marketplace

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5eaf02e9483239a86c591e84230d8