### PR TITLE
Use published base-lint CLI in demo app

### DIFF
--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -12,6 +12,10 @@ npm install
 npx base-lint scan --mode=repo --out .base-lint-report
 ```
 
+> **Note**
+>
+> The demo app depends on the published Base Lint CLI via a semver range so that you can verify what ships to npm. When working on the CLI locally, feel free to swap the dependency back to `workspace:*` to use the workspace build instead.
+
 After installing dependencies, you can also run the bundled script directly from the demo app directory:
 
 ```bash

--- a/examples/demo-app/package.json
+++ b/examples/demo-app/package.json
@@ -7,6 +7,6 @@
     "base-lint": "base-lint scan --mode=repo --out .base-lint-report"
   },
   "devDependencies": {
-    "base-lint": "base-lint"
+    "base-lint": "^1.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "name": "base-lint-demo-app",
       "version": "0.1.0",
       "devDependencies": {
-        "base-lint": "workspace:packages/cli"
+        "base-lint": "^1.0.1"
       }
     },
     "node_modules/@actions/core": {
@@ -1271,12 +1271,24 @@
       "license": "MIT"
     },
     "node_modules/base-lint": {
-      "resolved": "packages/cli",
-      "link": true
-    },
-    "examples/demo-app/node_modules/base-lint": {
-      "resolved": "packages/cli",
-      "link": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base-lint/-/base-lint-1.0.1.tgz",
+      "integrity": "sha512-XtHNQKKydJ9AS//nC4vMiQFaBSiNEJcB4VG8QAfatWQCflwC925rOdKpoUJWYBz+34W7g8TpSU2Mx/wfkMfREg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^6.21.0",
+        "commander": "^11.1.0",
+        "globby": "^13.2.2",
+        "ignore": "^5.3.1",
+        "minimatch": "^9.0.3",
+        "node-html-parser": "^6.1.11",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.35",
+        "web-features": "^2.0.0"
+      },
+      "bin": {
+        "base-lint": "dist/index.js"
+      }
     },
     "node_modules/base-lint-action": {
       "resolved": "packages/action",
@@ -2979,6 +2991,26 @@
       },
       "devDependencies": {
         "typescript": "^5.4.2"
+      }
+    },
+    "examples/demo-app/node_modules/base-lint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base-lint/-/base-lint-1.0.1.tgz",
+      "integrity": "sha512-XtHNQKKydJ9AS//nC4vMiQFaBSiNEJcB4VG8QAfatWQCflwC925rOdKpoUJWYBz+34W7g8TpSU2Mx/wfkMfREg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^6.21.0",
+        "commander": "^11.1.0",
+        "globby": "^13.2.2",
+        "ignore": "^5.3.1",
+        "minimatch": "^9.0.3",
+        "node-html-parser": "^6.1.11",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.35",
+        "web-features": "^2.0.0"
+      },
+      "bin": {
+        "base-lint": "dist/index.js"
       }
     },
     "packages/cli": {


### PR DESCRIPTION
## Summary
- update the demo app to depend on the published `base-lint` CLI via a caret semver range
- refresh the workspace lockfile so it resolves the CLI from the npm registry
- document how to switch back to `workspace:*` when developing the CLI locally

## Testing
- npm install --workspaces

------
https://chatgpt.com/codex/tasks/task_e_68d6653523f483239b09ebf4c5ebe148