### PR TITLE
feat(cli): silence parser ts version warnings

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,3 +16,11 @@ npm install --save-dev base-lint
 - `base-lint comment` – maintain a sticky pull request summary comment.
 
 Run `npx base-lint --help` for the full flag list.
+
+## TypeScript compatibility
+
+`base-lint` relies on `@typescript-eslint/typescript-estree` to parse TypeScript and
+JavaScript sources. The CLI suppresses the parser's unsupported TypeScript version
+banner by default, but the effective compatibility remains tied to the versions that
+`@typescript-eslint/typescript-estree` supports. Using newer or older TypeScript
+releases may lead to parsing errors until they are adopted by the upstream parser.

--- a/packages/cli/src/__tests__/ast-js.test.ts
+++ b/packages/cli/src/__tests__/ast-js.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+
+import { __setParseImplementationForTesting, parseJavaScript } from '../utils/ast-js.js';
+
+test('parseJavaScript disables TypeScript version warnings', (t) => {
+  const consoleWarn = mock.method(console, 'warn', () => {});
+
+  const parseSpy = mock.fn((code: string, options: Record<string, any> = {}) => {
+    assert.equal(code, 'const value = 1;');
+    if (options.warnOnUnsupportedTypeScriptVersion !== false) {
+      console.warn('unsupported TypeScript version');
+    }
+    if (typeof options.loggerFn === 'function') {
+      options.loggerFn('ts warning');
+    }
+    return {
+      type: 'Program',
+      body: [],
+      sourceType: 'module',
+      range: [0, 0],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 0 },
+      },
+    } as never;
+  });
+
+  __setParseImplementationForTesting(parseSpy as any);
+
+  t.after(() => {
+    consoleWarn.mock.restore();
+    __setParseImplementationForTesting(null);
+  });
+
+  const program = parseJavaScript('const value = 1;', 'file.ts');
+
+  assert.ok(program);
+  assert.equal(parseSpy.mock.calls.length, 1);
+  const [, options] = parseSpy.mock.calls[0].arguments as [string, Record<string, unknown>];
+  assert.equal(options.warnOnUnsupportedTypeScriptVersion, false);
+  assert.equal(typeof options.loggerFn, 'function');
+  assert.equal(consoleWarn.mock.calls.length, 0);
+});

--- a/packages/cli/src/utils/ast-js.ts
+++ b/packages/cli/src/utils/ast-js.ts
@@ -1,15 +1,25 @@
 import { parse } from '@typescript-eslint/typescript-estree';
 import type { TSESTree } from '@typescript-eslint/typescript-estree';
 
+let parseImplementation = parse;
+
+export function __setParseImplementationForTesting(
+  implementation: typeof parse | null,
+): void {
+  parseImplementation = implementation ?? parse;
+}
+
 export function parseJavaScript(code: string, filePath: string): TSESTree.Program | null {
   try {
-    return parse(code, {
+    return parseImplementation(code, {
       loc: true,
       range: true,
       jsx: filePath.endsWith('x'),
       comment: false,
       errorOnUnknownASTType: false,
       useJSXTextNode: true,
+      warnOnUnsupportedTypeScriptVersion: false,
+      loggerFn: () => {},
     });
   } catch (error) {
     return null;


### PR DESCRIPTION
## Summary
- disable the TypeScript version warning emitted by the parser when the CLI parses files
- add a unit test that verifies the parser options suppress the warning and use a no-op logger
- document the effective TypeScript compatibility expectations for the CLI

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d71526590c8323b226856efa442880