### PR TITLE
feat(cli): print scan summary to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npx base-lint annotate --input .base-lint-report/report.json
 npx base-lint comment --input .base-lint-report/report.md
 ```
 
+`base-lint scan` prints a condensed Markdown summary to stdout after writing the reports. Pass `--print-full-report` or open `.base-lint-report/report.md` for the full table when you need additional context.
+
 ## Configuration
 
 Create an optional `base-lint.config.json` at the repository root:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,12 +45,13 @@
 
    > 💡 **Diff vs. full scan:** Omit `--mode=diff` to analyze the entire codebase, which is helpful for scheduled audits or first-time rollouts.
 
-3. **Interpret the results** from the generated Markdown summary:
+3. **Interpret the results** from the generated Markdown summary (a condensed version prints to the terminal after each scan):
 
    ```bash
    cat .base-lint-report/report.md
    ```
 
+   - Pass `--print-full-report` to `scan` to stream the entire Markdown table to stdout.
    - The Markdown file includes a status badge and tables you can paste into pull requests.
    - The accompanying `report.json` is consumable by automation (see [`enforce`](#base-lint-enforce)).
 
@@ -97,7 +98,7 @@ Analyze your repository (or just the current diff) and emit structured reports.
 npx base-lint scan --mode=diff --out .base-lint-report
 ```
 
-By default the CLI outputs to `.base-lint-report/` in the current working directory. Every run writes `report.json`, `report.md`, and `meta.json`, then prints the folder location to stdout. The Markdown report includes a status summary and a table of findings that you can link from PR descriptions or surface in GitHub comments.
+By default the CLI outputs to `.base-lint-report/` in the current working directory. Every run writes `report.json`, `report.md`, and `meta.json`, then prints both a condensed Markdown summary (or the full table with `--print-full-report`) and the folder location to stdout. The Markdown report includes a status summary and a table of findings that you can link from PR descriptions or surface in GitHub comments.
 
 ### `base-lint enforce`
 

--- a/packages/cli/src/core/reporters/summary.ts
+++ b/packages/cli/src/core/reporters/summary.ts
@@ -1,0 +1,38 @@
+export function formatMarkdownSummary(markdownReport: string, maxRows = 5): string {
+  const lines = markdownReport.split('\n');
+  const filtered = lines.filter((line, index) => !(index === 0 && line.startsWith('<!--')));
+  const result: string[] = [];
+
+  for (let index = 0; index < filtered.length; index += 1) {
+    const line = filtered[index];
+    if (line.startsWith('|------')) {
+      result.push(line);
+      const dataRows: string[] = [];
+      let dataIndex = index + 1;
+      while (dataIndex < filtered.length) {
+        const row = filtered[dataIndex];
+        if (!row.startsWith('|')) {
+          break;
+        }
+        dataRows.push(row);
+        dataIndex += 1;
+      }
+      const visibleRows = dataRows.slice(0, maxRows);
+      result.push(...visibleRows);
+      if (dataRows.length > maxRows) {
+        const remaining = dataRows.length - maxRows;
+        result.push(`| … | … | … | … | … (${remaining} more) |`);
+      }
+      index = dataIndex - 1;
+      continue;
+    }
+
+    if (line.startsWith('<!--')) {
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  return result.join('\n').trimEnd();
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ program
   .option('--strict', 'enable strict feature detection')
   .option('--treat-newly <behavior>', 'treat Newly features as warn|error|ignore', 'warn')
   .option('--config <path>', 'path to config file override')
+  .option('--print-full-report', 'print the full Markdown report to stdout')
   .action(async (options) => {
     try {
       await runScanCommand(options);

--- a/tests/e2e/cli-scan.test.mjs
+++ b/tests/e2e/cli-scan.test.mjs
@@ -47,7 +47,7 @@ test('scan command generates baseline reports in repo mode', async (t) => {
   });
   t.after(cleanup);
 
-  await runCli(
+  const result = await runCli(
     ['scan', '--mode', 'repo', '--out', '.base-lint-report', '--treat-newly', 'warn'],
     { cwd: workspace },
   );
@@ -74,4 +74,8 @@ test('scan command generates baseline reports in repo mode', async (t) => {
   const markdown = await readFile(path.join(reportDir, 'report.md'), 'utf8');
   assert.ok(markdown.includes('web.usb'));
   assert.ok(markdown.includes('css.has-selector'));
+
+  assert.ok(result.stdout.includes('## Base Lint Report'));
+  assert.ok(result.stdout.includes('**Status:**'));
+  assert.ok(result.stdout.includes('web.usb'));
 });


### PR DESCRIPTION
## Summary
- print a condensed Markdown summary after each `base-lint scan` run and add a `--print-full-report` flag
- share the Markdown summarizer between the CLI and e2e helper to validate terminal output
- update the CLI documentation to mention the new terminal summary and opt-in full report flag

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d7678eeae4832392b85c9053b22add