### PR TITLE
Add demo app Base Lint configuration example

### DIFF
--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -16,6 +16,39 @@ Tiny demo project with a couple of features that Base Lint will flag:
 | examples/demo-app/src/styles.css | 1 | :has() | Newly |
 ```
 
+## Configuration
+
+The demo app ships with a ready-to-use `base-lint.config.json` that mirrors a
+typical CI setup:
+
+```jsonc
+{
+  "mode": "diff",            // focus on changes in pull requests
+  "strict": true,             // exit with a non-zero code on Limited findings
+  "treatNewlyAs": "warn",     // keep Newly findings visible without failing CI
+  "maxLimited": 0,            // allow zero Limited findings in the diff
+  "include": [
+    "src/**/*.{ts,tsx,css}",
+    "public/**/*.html"
+  ],
+  "ignore": [
+    "**/*.test.{ts,tsx}",
+    "src/mocks/**"
+  ]
+}
+```
+
+Drop the config into your own repository to adopt the same defaults. Tweak the
+settings to match your workflow:
+
+- Switch `mode` to `repo` for full repository scans (e.g. scheduled jobs).
+- Set `treatNewlyAs` to `error` if Newly features should also fail the build, or
+  to `ignore` to silence them entirely.
+- Expand `include`/`ignore` patterns to match your project layout; the demo
+  configuration keeps focus on source files while skipping tests and mocks.
+
+## Running the CLI
+
 Run the CLI from the repository root to generate a report:
 
 ```bash
@@ -28,8 +61,20 @@ npx base-lint clean --out .base-lint-report
 >
 > The demo app depends on the published Base Lint CLI via a semver range so that you can verify what ships to npm. When working on the CLI locally, feel free to swap the dependency back to `workspace:*` to use the workspace build instead.
 
-After installing dependencies, you can also run the bundled script directly from the demo app directory:
+After installing dependencies, you can also run Base Lint directly from the demo
+app directory with the included configuration. The CLI automatically detects the
+local `base-lint.config.json`, so you only need to run:
+
+```bash
+npx base-lint scan
+```
+
+Or use the bundled script:
 
 ```bash
 npm run base-lint
 ```
+
+Because the config defaults to `mode: diff`, the CLI scans only files changed
+relative to your current Git branch. Add a staged change or append
+`--mode=repo` to lint the entire workspace in one run.

--- a/examples/demo-app/base-lint.config.json
+++ b/examples/demo-app/base-lint.config.json
@@ -1,0 +1,16 @@
+{
+  "mode": "diff",
+  "strict": true,
+  "treatNewlyAs": "warn",
+  "maxLimited": 0,
+  "targets": "all",
+  "suppress": [],
+  "include": [
+    "src/**/*.{ts,tsx,css}",
+    "public/**/*.html"
+  ],
+  "ignore": [
+    "**/*.test.{ts,tsx}",
+    "src/mocks/**"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a diff-mode `base-lint.config.json` to the demo app with strict defaults and path filters
- expand the demo README with guidance on tweaking the config and running the scan command

## Testing
- npx base-lint scan


------
https://chatgpt.com/codex/tasks/task_e_68d8b23e82f48323adfb9f972523f547