### PR TITLE
docs: clarify configuration and ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,18 @@ Create an optional `base-lint.config.json` at the repository root:
 }
 ```
 
-Ignore additional paths by creating `.base-lintignore` (same format as `.gitignore`). Default ignore entries:
+Field reference:
+
+- **`mode`** (default: `"diff"`) – Choose between scanning only the current Git diff (`"diff"`) or the entire repository (`"repo"`). Diff mode keeps pull requests focused on new changes, while repo mode is ideal for scheduled audits and initial migrations.
+- **`treatNewlyAs`** (default: `"warn"`) – Decide how Newly Baseline findings behave. Use `"warn"` to surface them without breaking CI, `"error"` to fail builds that introduce Newly features, or `"ignore"` to silence them entirely when you only care about Limited gaps.
+- **`maxLimited`** (default: `0`) – Set the number of Limited findings tolerated by `base-lint enforce`. Raising the threshold lets teams roll out Base Lint gradually while they pay down existing debt.
+- **`strict`** (default: `false`) – Enable stricter feature detection heuristics, such as reporting computed property access. Turn this on when you want the most defensive signal, or leave it off to reduce noise from dynamic code.
+- **`targets`** (default: `"all"`) – Reserved for future Baseline targeting controls. Keep the default unless you are experimenting with internal builds that scope analysis to a specific audience.
+- **`suppress`** (default: `[]`) – Provide Baseline feature IDs to mute when you have hand-reviewed fallbacks or intentionally accepted risk (for example, suppressing `has` after documenting a polyfill strategy).
+- **`include`** (default: `[]`) – Supply glob patterns that act as an allowlist. Leave empty to scan everything the mode selects, or narrow the scan to specific folders (e.g., `"src/**/*"`) when only part of the repo should be linted.
+- **`ignore`** (default: `[]`) – Add project-wide ignore patterns that apply to every invocation. These values augment Base Lint’s built-in defaults and any `.base-lintignore` entries.
+
+Ignore additional paths by creating `.base-lintignore` (same format as `.gitignore`). Base Lint always starts with its built-in defaults and then appends the config and ignore-file entries when assembling the matcher (see [`packages/cli/src/config.ts`](packages/cli/src/config.ts)). Default ignore entries:
 
 ```
 node_modules/
@@ -91,6 +102,18 @@ build/
 coverage/
 *.min.js
 ```
+
+Example `.base-lintignore` snippet:
+
+```
+# Skip generated Storybook output checked into docs
+storybook-static/
+
+# Drop vendored playground builds
+apps/*/sandbox/dist/
+```
+
+Use the `ignore` array in `base-lint.config.json` for patterns that should travel with the repository (shared generated folders, vendored dependencies, etc.). Reach for `.base-lintignore` when individuals or ephemeral environments need extra exclusions without editing the shared config (for example, local build caches or experimental directories).
 
 CLI flags override config values, and config overrides defaults.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -189,7 +189,37 @@ Dive deeper into configuration and automation patterns once the basics are in pl
 
 ### Configuration
 
-- **`base-lint.config.json`** – Optional configuration file resolved from the repository root (or the path you pass to `--config`). Use it to set defaults for scan mode, failure thresholds, suppressions, and path include/ignore lists.
-- **`.base-lintignore`** – Optional ignore file that uses `.gitignore` semantics and is merged with the built-in ignore list (`node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`).
+- **`base-lint.config.json`** – Optional configuration file resolved from the repository root (or the path you pass to `--config`).
+  - **`mode`** (default: `"diff"`) – Scan only the current Git diff (`"diff"`) or the entire repository (`"repo"`). Diff mode keeps PR noise low; repo mode suits full audits and rollouts.
+  - **`treatNewlyAs`** (default: `"warn"`) – Control how Newly Baseline findings behave. Pick `"warn"` to surface issues without failing, `"error"` to block merges, or `"ignore"` when you only care about Limited features.
+  - **`maxLimited`** (default: `0`) – Maximum Limited findings tolerated by `base-lint enforce`. Increase it to phase Base Lint in while you fix legacy gaps.
+  - **`strict`** (default: `false`) – Enable stricter detection heuristics (for example, computed property access). Useful when you want the strongest signal, otherwise leave off to avoid noisy dynamic cases.
+  - **`targets`** (default: `"all"`) – Reserved for upcoming Baseline targeting controls. Stick with the default unless you are experimenting with pre-release dataset filters.
+  - **`suppress`** (default: `[]`) – List Baseline feature IDs to mute after you have documented fallbacks or accepted the risk.
+  - **`include`** (default: `[]`) – Glob patterns that act as an allowlist. Empty means “consider everything the mode collects”; provide paths such as `"src/**/*"` to narrow the scan.
+  - **`ignore`** (default: `[]`) – Additional ignore globs that apply to all runs. These are added on top of the built-in defaults and anything in `.base-lintignore`.
+- **`.base-lintignore`** – Optional ignore file that uses `.gitignore` semantics. Base Lint appends its entries to the core defaults and config ignores during resolution (see [`packages/cli/src/config.ts`](./src/config.ts)).
+
+Default ignore entries:
+
+```
+node_modules/
+dist/
+build/
+coverage/
+*.min.js
+```
+
+Example `.base-lintignore` snippet:
+
+```
+# Skip generated Storybook output checked into docs
+storybook-static/
+
+# Drop vendored playground builds
+apps/*/sandbox/dist/
+```
+
+Use the `ignore` array in `base-lint.config.json` for repository-wide exclusions that every environment should share, and reserve `.base-lintignore` for local or ephemeral directories that individual developers need to silence without editing the shared config.
 
 Configuration files override the CLI defaults, and direct flags always win over configuration. For full option descriptions and additional examples, see the [Base Lint configuration guide](../../README.md#configuration).


### PR DESCRIPTION
## Summary
- expand the configuration guides in both READMEs with field-by-field defaults and usage notes
- document how `.base-lintignore` merges with built-in patterns and provide an example snippet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b3f849d08323b9e5ad25f5d50745