### PR TITLE
Default base-lint enforce to generated report

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ jobs:
 ```bash
 npm i -D base-lint
 npx base-lint scan
-npx base-lint enforce --input .base-lint-report/report.json
+npx base-lint enforce
 # optional GitHub integrations
 npx base-lint annotate --input .base-lint-report/report.json
 npx base-lint comment --input .base-lint-report/report.md
 ```
+
+`base-lint enforce` automatically reads `.base-lint-report/report.json`. If `scan` writes to a custom `--out`, pass the matching `--input` when enforcing (for example, `base-lint enforce --input custom-dir/report.json`).
 
 > ℹ️ **GitHub Actions context:** `base-lint annotate` and `base-lint comment` assume they are running inside GitHub Actions wher
 e `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, `GITHUB_EVENT_NAME`, and `GITHUB_SHA` are automatically provided. Other CI or local enviro
@@ -59,7 +61,7 @@ on/README.md`](packages/action/README.md) for how the token is issued and why fo
 |  | `--treat-newly <behavior>` | `warn` | Controls whether Newly findings warn, error, or are ignored. |
 |  | `--config <path>` | — | Override path to `base-lint.config.json`. |
 |  | `--print-full-report` | `false` | Prints the full Markdown report to stdout. |
-| `enforce` | `--input <file>` | Required | Path to a JSON report emitted by `scan`. |
+| `enforce` | `--input <file>` | `.base-lint-report/report.json` | Path to a JSON report emitted by `scan` (override when `scan --out` changes). |
 |  | `--max-limited <count>` | `0` | Maximum allowed Limited findings before failing. |
 |  | `--fail-on-warn` | `false` | Treat Newly findings as failures. |
 | `annotate` | `--input <file>` | Required | JSON report to create GitHub Checks annotations from. |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -118,14 +118,16 @@ Prefer to change these defaults globally? See [Configuration](#configuration).
 Gate your CI workflow based on the JSON scan results.
 
 ```bash
-npx base-lint enforce --input .base-lint-report/report.json
+npx base-lint enforce
 ```
+
+`base-lint enforce` automatically reads `.base-lint-report/report.json`. If `scan` writes to a custom `--out`, pass the matching `--input` when enforcing (for example, `base-lint enforce --input custom-dir/report.json`).
 
 `--max-limited` defaults to `0`, so the command fails if any Limited findings remain. Set `--fail-on-warn` (or configure `treatNewlyAs: "error"`) when Newly findings should also block merges.
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--input <file>` | Required | JSON report emitted by `scan`. |
+| `--input <file>` | `.base-lint-report/report.json` | JSON report emitted by `scan` (override when `scan --out` changes). |
 | `--max-limited <count>` | `0` | Maximum allowed Limited findings before failing. |
 | `--fail-on-warn` | `false` | Treat Newly findings as failures. |
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,1 +1,4 @@
+import path from 'path';
+
 export const DEFAULT_REPORT_DIRECTORY = '.base-lint-report';
+export const DEFAULT_REPORT_PATH = path.join(DEFAULT_REPORT_DIRECTORY, 'report.json');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { runEnforceCommand } from './commands/enforce.js';
 import { runCommentCommand } from './commands/comment.js';
 import { runAnnotateCommand } from './commands/annotate.js';
 import { runCleanCommand } from './commands/clean.js';
-import { DEFAULT_REPORT_DIRECTORY } from './constants.js';
+import { DEFAULT_REPORT_DIRECTORY, DEFAULT_REPORT_PATH } from './constants.js';
 import pkg from '../package.json' with { type: 'json' };
 
 const program = new Command();
@@ -34,12 +34,15 @@ program
 program
   .command('enforce')
   .description('Enforce policy against a previously generated JSON report')
-  .requiredOption('--input <file>', 'path to JSON report')
+  .option('--input <file>', 'path to JSON report', DEFAULT_REPORT_PATH)
   .option('--max-limited <count>', 'maximum number of limited findings', '0')
   .option('--fail-on-warn', 'treat Newly findings as failures')
-  .action(async (options) => {
+  .action(async (options, command) => {
     try {
-      await runEnforceCommand(options);
+      await runEnforceCommand({
+        ...options,
+        inputSource: command.getOptionValueSource('input'),
+      });
     } catch (error) {
       handleError(error);
     }

--- a/tests/e2e/enforce-defaults.test.mjs
+++ b/tests/e2e/enforce-defaults.test.mjs
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createWorkspace, runCli } from './helpers.js';
+import { DEFAULT_REPORT_PATH } from '../../packages/cli/src/constants.ts';
+
+test('enforce succeeds with default report path after scan', async (t) => {
+  const { workspace, cleanup } = await createWorkspace({
+    'src/app.js': 'navigator.usb.requestDevice({ filters: [] });\n',
+  });
+  t.after(cleanup);
+
+  await runCli(['scan', '--mode', 'repo'], { cwd: workspace });
+
+  const output = await runCli(['enforce', '--max-limited', '1'], { cwd: workspace });
+
+  assert.ok(
+    output.stdout.includes('Baseline policy satisfied.'),
+    'enforce should confirm the policy was satisfied',
+  );
+});
+
+test('enforce prints guidance when default report is missing', async (t) => {
+  const { workspace, cleanup } = await createWorkspace({});
+  t.after(cleanup);
+
+  await assert.rejects(
+    runCli(['enforce'], { cwd: workspace }),
+    (error) => {
+      assert.equal(error.message, 'enforce command exited with code 1');
+      assert.ok(error.output, 'output should be attached to the error');
+      assert.ok(
+        error.output.stderr.includes(
+          `[base-lint] No report found at ${DEFAULT_REPORT_PATH} — run \`base-lint scan\` first or pass --input`,
+        ),
+        'stderr should include the missing report guidance',
+      );
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- default the CLI enforce command to read the generated .base-lint-report/report.json
- surface a clear warning when the default report is missing and let docs explain overriding it
- add e2e coverage and helpers to exercise the default path and missing report guidance

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d9b89d6fdc832380c0cf56948f0faa