### PR TITLE
Add root action manifest referencing compiled bundle

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-# NOTE: Keep this manifest in sync with /action.yml
+# NOTE: Keep this manifest in sync with packages/action/action.yml
 name: 'Base Lint Action'
 description: 'Run base-lint in CI, enforce policy, and post PR feedback'
 author: 'Base Lint Contributors'
@@ -20,7 +20,7 @@ inputs:
     default: 'true'
 runs:
   using: 'node20'
-  main: 'dist/index.js'
+  main: 'packages/action/dist/index.js'
 branding:
   color: 'blue'
   icon: 'shield'


### PR DESCRIPTION
## Summary
- add a root GitHub Action manifest that mirrors the workspace action configuration and references the compiled bundle
- note in both manifests that they must stay in sync

## Testing
- npm run build -w packages/action

------
https://chatgpt.com/codex/tasks/task_e_68d9f4d012788323b5821350a2f74ee4