### PR TITLE
docs: align GitHub Action docs with root manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: your-org/base-lint-action@v1
+      - uses: <owner>/<repo>@<tag>
         with:
           mode: diff
           max-limited: 0
@@ -32,6 +32,10 @@ jobs:
           comment: true
           checks: true
 ```
+
+The GitHub Action metadata now lives at the repository root in [`action.yml`](./action.yml) while the compiled bundle continues
+to ship from [`packages/action/dist`](packages/action/dist). Build and commit the bundle whenever you update the TypeScript
+sources so published tags include the refreshed JavaScript.
 
 ### CLI
 
@@ -203,10 +207,12 @@ The repository favors mock-heavy unit tests to keep feedback loops tight. When a
 
 ### Release the GitHub Action to the Marketplace
 
-1. Update the version in `packages/action/package.json` and `packages/action/action.yml`.
+1. Update the version in `packages/action/package.json`, `packages/action/action.yml`, and the root [`action.yml`](./action.yml) so both manifests stay in sync.
 2. Rebuild the bundle with `npm run build -w packages/action` and commit the resulting `packages/action/dist` output.
 3. Create a Git tag (`git tag action-vX.Y.Z && git push origin action-vX.Y.Z`).
 4. Draft a GitHub release that points to the new tag—Marketplace listings pick up the bundled `dist/` assets automatically.
+
+Refer to the [`packages/action` release checklist](packages/action/README.md#release-checklist) for the package-level perspective on the same workflow.
 
 ## Security & Privacy
 

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -5,7 +5,7 @@ GitHub Action wrapper for the `base-lint` CLI. See [`packages/cli`](../cli) for 
 ## Usage
 
 ```yaml
-- uses: your-org/base-lint-action@v1
+- uses: <owner>/<repo>@<tag>
   with:
     mode: diff
     max-limited: 0
@@ -14,10 +14,19 @@ GitHub Action wrapper for the `base-lint` CLI. See [`packages/cli`](../cli) for 
     checks: true
 ```
 
+The action manifest exposed to users lives at the repository root (`../../action.yml`) and re-exports the bundle built from this
+workspace's sources.
+
 ## Release checklist
 
 Before tagging a new release:
 
-1. Run `npm run build -w packages/action` to regenerate the bundled `dist/` output referenced by [`action.yml`](./action.yml).
-2. Commit any changes under `packages/action/dist` so the published tag always includes the compiled JavaScript.
-3. Verify CI passes to ensure the action bundle remains in sync with the TypeScript sources.
+1. Run `npm run build -w packages/action` to regenerate the bundled `dist/` output consumed by both manifests.
+2. Update [`../../action.yml`](../../action.yml) together with [`./action.yml`](./action.yml) so the root- and package-level metadata
+   reference the same version and entrypoint.
+3. Commit the refreshed bundle under `packages/action/dist` (and any manifest changes) so the published tag always includes the
+   compiled JavaScript.
+4. Verify CI passes to ensure the action bundle remains in sync with the TypeScript sources.
+
+These steps mirror the repository-level guidance in the [Release the GitHub Action to the Marketplace](../../README.md#release-the-github-action-to-the-marketplace)
+section.


### PR DESCRIPTION
## Summary
- update the top-level README to reference the root action.yml, keep the build requirement, and point release steps at the action package docs
- refresh the action package README to mention the root manifest, ensure both checklists stay synchronized, and cross-link back to the repo instructions

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d9fcdcd3b083238e7b7fb3367a74a5