### PR TITLE
Update CLI package homepage URL

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "bugs": {
     "url": "https://github.com/ej-sanmartin/base-lint/issues"
   },
-  "homepage": "https://github.com/web-baseline/base-lint#readme",
+  "homepage": "https://github.com/ej-sanmartin/base-lint#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/ej-sanmartin/base-lint",


### PR DESCRIPTION
## Summary
- update the CLI package homepage to the repository's README URL
- check for additional references to the deprecated web-baseline slug

## Testing
- rg "web-baseline" -n

------
https://chatgpt.com/codex/tasks/task_e_68da1eb6ddac83238f67f2fc5d936812