### PR TITLE
Update README badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Lint your repo against Web Baseline. PR-safe. Zero-config.
 
-[![CI](https://img.shields.io/badge/ci-passing-green.svg)](#) [![npm](https://img.shields.io/badge/npm-base--lint-orange.svg)](#) [![GitHub release](https://img.shields.io/badge/action-base--lint--action-blue.svg)](#)
+[![CI](https://img.shields.io/badge/ci-passing-green.svg)](#) [![npm](https://img.shields.io/badge/npm-base--lint-orange.svg)](https://www.npmjs.com/package/base-lint) [![GitHub release](https://img.shields.io/badge/action-base--lint--action-blue.svg)](https://github.com/marketplace/actions/base-lint-action)
 
 ![Baseline Shield Logo Thumbnail](assets/base-lint-thumbnail.png)
 


### PR DESCRIPTION
## Summary
- update the README npm badge to link to the base-lint package on npm
- point the GitHub Action badge to the Base Lint action marketplace listing

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68da2024860c832383930b7fb02cf6f2