### PR TITLE
Document GitHub Action tag naming

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,7 +59,8 @@ The repository favors mock-heavy unit tests to keep feedback loops tight. When a
 
 1. Update the version in `packages/action/package.json`, `packages/action/action.yml`, and the root [`action.yml`](./action.yml) so both manifests stay in sync.
 2. Rebuild the bundle with `npm run build -w packages/action` and commit the resulting `packages/action/dist` output.
-3. Create a Git tag (`git tag action-vX.Y.Z && git push origin action-vX.Y.Z`).
-4. Draft a GitHub release that points to the new tag—Marketplace listings pick up the bundled `dist/` assets automatically.
+3. Verify the tag naming matches the `base-lint-action-v*` pattern before publishing (for example, `git tag --list 'base-lint-action-v*'`).
+4. Create a Git tag (`git tag base-lint-action-vX.Y.Z && git push origin base-lint-action-vX.Y.Z`).
+5. Draft a GitHub release that points to the new tag—Marketplace listings pick up the bundled `dist/` assets automatically.
 
 Refer to the [`packages/action` release checklist](packages/action/README.md#release-checklist) for the package-level perspective on the same workflow.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: <owner>/<repo>@<tag>
+      - uses: ej-sanmartin/base-lint@base-lint-action-vX.Y.Z
         with:
           mode: diff
           max-limited: 0
@@ -37,7 +37,8 @@ jobs:
 
 The GitHub Action metadata now lives at the repository root in [`action.yml`](./action.yml) while the compiled bundle continues
 to ship from [`packages/action/dist`](packages/action/dist). Build and commit the bundle whenever you update the TypeScript
-sources so published tags include the refreshed JavaScript.
+sources so published tags include the refreshed JavaScript. Marketplace releases follow the `base-lint-action-v*` tag naming
+rule (for example, `base-lint-action-v1.0.0`).
 
 ### CLI
 

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -5,7 +5,7 @@ GitHub Action wrapper for the `base-lint` CLI. See [`packages/cli`](../cli) for 
 ## Usage
 
 ```yaml
-- uses: <owner>/<repo>@<tag>
+- uses: ej-sanmartin/base-lint@base-lint-action-vX.Y.Z
   with:
     mode: diff
     max-limited: 0


### PR DESCRIPTION
## Summary
- document the `base-lint-action-v*` tag pattern in the GitHub Action release checklist
- update README usage examples to reference `ej-sanmartin/base-lint@base-lint-action-vX.Y.Z`

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dad5915f948323875962c1bcc3109a