### PR TITLE
Document fetch-depth requirement for Base Lint diff mode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ej-sanmartin/base-lint@base-lint-action-vX.Y.Z
         with:
           mode: diff
@@ -34,6 +36,8 @@ jobs:
           comment: true
           checks: true
 ```
+
+Diff mode needs the base commit to be present locally, so configure `actions/checkout` with `fetch-depth: 0` (or switch Base Lint to `mode: repo`) to avoid fetching only the latest commit. Without the deeper history, Base Lint falls back to scanning nothing and reports “No files matched the scan configuration.”
 
 The GitHub Action metadata now lives at the repository root in [`action.yml`](./action.yml) while the compiled bundle continues
 to ship from [`packages/action/dist`](packages/action/dist). Build and commit the bundle whenever you update the TypeScript


### PR DESCRIPTION
## Summary
- set the GitHub Action quickstart example to fetch the full history so diff mode can compare against the base commit
- document that without a deeper fetch (or by switching to repo mode) Base Lint will report “No files matched the scan configuration”

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68daf29628c8832393523d70cb1fa712