### PR TITLE
feat: forward GitHub token input to the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
           fetch-depth: 0
       - uses: ej-sanmartin/base-lint@base-lint-action-vX.Y.Z
         with:
+          github-token: ${{ github.token }}
           mode: diff
           max-limited: 0
           treat-newly-as: warn

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,8 @@ name: 'Base Lint Action'
 description: 'Run base-lint in CI to enforce baseline accessibility standards and automatically comment with PR feedback.'
 author: 'Base Lint Contributors'
 inputs:
+  github-token:
+    description: 'GitHub token used for API requests'
   mode:
     description: 'Scan mode (diff or repo)'
     default: 'diff'

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -7,6 +7,7 @@ GitHub Action wrapper for the `base-lint` CLI. See [`packages/cli`](../cli) for 
 ```yaml
 - uses: ej-sanmartin/base-lint@base-lint-action-vX.Y.Z
   with:
+    github-token: ${{ github.token }}
     mode: diff
     max-limited: 0
     treat-newly-as: warn

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -3,6 +3,8 @@ name: 'Base Lint Action'
 description: 'Run base-lint in CI, enforce policy, and post PR feedback'
 author: 'Base Lint Contributors'
 inputs:
+  github-token:
+    description: 'GitHub token used for API requests'
   mode:
     description: 'Scan mode (diff or repo)'
     default: 'diff'

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -120,6 +120,19 @@ var import_child_process = require("child_process");
 var import_path = __toESM(require("path"));
 var import_url = require("url");
 var import_meta = {};
+var missingTokenWarningIssued = false;
+function resolveGithubToken() {
+  const inputToken = getInput("github-token");
+  const envToken = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const resolvedToken = inputToken || envToken;
+  if (!resolvedToken && !missingTokenWarningIssued) {
+    warning(
+      "No GitHub token supplied. Provide one via `with: github-token: ${{ github.token }}` or set the `GITHUB_TOKEN` environment variable to enable annotations and comments."
+    );
+    missingTokenWarningIssued = true;
+  }
+  return resolvedToken;
+}
 async function main() {
   try {
     const mode = getInput("mode") || "diff";
@@ -178,8 +191,15 @@ async function runBaseLint(args, deps = {}) {
   const spawnFn = deps.spawn ?? import_child_process.spawn;
   coreApi.info(`Running base-lint ${args.join(" ")}`);
   await new Promise((resolve, reject) => {
+    const githubToken = resolveGithubToken();
+    const childEnv = { ...process.env };
+    if (githubToken) {
+      childEnv.GITHUB_TOKEN = githubToken;
+      childEnv.GH_TOKEN = githubToken;
+    }
     const proc = spawnFn("npx", ["--yes", "base-lint", ...args], {
-      stdio: "inherit"
+      stdio: "inherit",
+      env: childEnv
     });
     proc.on("error", (error2) => reject(error2));
     proc.on("close", (code) => {


### PR DESCRIPTION
## Summary
- add an optional `github-token` input that falls back to the `GITHUB_TOKEN` environment variable
- pass the resolved token through the action's child process environment and surface a warning when it is missing
- document the new input in the README files and rebuild the bundled `dist` output

## Testing
- npm test -- packages/action
- npm run build -w packages/action

------
https://chatgpt.com/codex/tasks/task_e_68db504858508323ab8d8a073eb3dab9