### PR TITLE
Handle new coverage summary format

### DIFF
--- a/scripts/run-unit-tests.mjs
+++ b/scripts/run-unit-tests.mjs
@@ -85,28 +85,92 @@ child.on('close', (code, signal) => {
     process.exit(code ?? 1);
   }
 
-  const coverageLine = stdout
+  const lines = stdout
     .split(/\r?\n/)
-    .map((line) => line.trim().replace(/\u2026/g, '...'))
-    .find((line) => line.toLowerCase().startsWith('ℹ all') || line.toLowerCase().startsWith('# all'));
+    .map((line) => line.trim().replace(/\u2026/g, '...'));
 
-  if (!coverageLine) {
+  const coverageLineIndex = lines.findIndex(
+    (line) => line.toLowerCase().startsWith('ℹ all') || line.toLowerCase().startsWith('# all'),
+  );
+
+  if (coverageLineIndex === -1) {
     console.error('Coverage summary not found in test output.');
     process.exit(1);
   }
 
-  const match = coverageLine.match(/\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)/);
-  if (!match) {
-    console.error('Unable to parse coverage percentages from summary line:', coverageLine);
-    process.exit(1);
+  const parseColumns = (row) =>
+    row
+      .split('|')
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0);
+
+  let metrics;
+
+  const headerOffset = lines
+    .slice(coverageLineIndex + 1)
+    .findIndex((line) => {
+      const lower = line.toLowerCase();
+      const hasFunctionColumn = lower.includes('functions') || lower.includes('funcs');
+      return lower.includes('lines') && lower.includes('branches') && hasFunctionColumn && line.includes('|');
+    });
+
+  if (headerOffset !== -1) {
+    const headerIndex = coverageLineIndex + 1 + headerOffset;
+    const dataOffset = lines
+      .slice(headerIndex + 1)
+      .findIndex((line) => /\d+(?:\.\d+)?%/.test(line));
+
+    if (dataOffset !== -1) {
+      const headerColumns = parseColumns(lines[headerIndex]);
+      const dataColumns = parseColumns(lines[headerIndex + 1 + dataOffset]);
+      const columnMap = {
+        lines: headerColumns.findIndex((value) => value.toLowerCase().startsWith('lines')),
+        branches: headerColumns.findIndex((value) => value.toLowerCase().startsWith('branches')),
+        functions: headerColumns.findIndex((value) => {
+          const lower = value.toLowerCase();
+          return lower.startsWith('functions') || lower.startsWith('funcs');
+        }),
+      };
+
+      const parsedMetrics = {};
+      let isValid = true;
+
+      for (const [key, columnIndex] of Object.entries(columnMap)) {
+        if (columnIndex === -1 || columnIndex >= dataColumns.length) {
+          isValid = false;
+          break;
+        }
+
+        const numeric = Number.parseFloat(dataColumns[columnIndex].replace(/%/g, ''));
+        if (Number.isNaN(numeric)) {
+          isValid = false;
+          break;
+        }
+
+        parsedMetrics[key] = numeric;
+      }
+
+      if (isValid) {
+        metrics = parsedMetrics;
+      }
+    }
   }
 
-  const [, linePercent, branchPercent, funcPercent] = match;
-  const metrics = {
-    lines: Number.parseFloat(linePercent),
-    branches: Number.parseFloat(branchPercent),
-    functions: Number.parseFloat(funcPercent),
-  };
+  if (!metrics) {
+    const coverageLine = lines[coverageLineIndex];
+    const match = coverageLine.match(/\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)/);
+    if (!match) {
+      console.error('Unable to parse coverage percentages from summary line:', coverageLine);
+      process.exit(1);
+    }
+
+    const [, linePercent, branchPercent, funcPercent] = match;
+    metrics = {
+      lines: Number.parseFloat(linePercent),
+      branches: Number.parseFloat(branchPercent),
+      functions: Number.parseFloat(funcPercent),
+    };
+  }
 
   const failures = Object.entries(metrics).filter(([, value]) => value < threshold);
   if (failures.length > 0) {


### PR DESCRIPTION
## Summary
- parse the coverage table header and data rows that follow the "ℹ all files" marker to extract line, branch, and function coverage
- retain the legacy summary parsing logic as a fallback when the table is not present

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68db926604e48323b4315177f449833c