### PR TITLE
Refactor CLI report formatting into a registry

### DIFF
--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -3,8 +3,7 @@ import { globby } from 'globby';
 import { minimatch } from 'minimatch';
 import ignore from 'ignore';
 import { analyze } from '../core/analyze.js';
-import { createJsonReport } from '../core/reporters/json.js';
-import { createMarkdownReport } from '../core/reporters/markdown.js';
+import { formatReport } from '../core/formats/index.js';
 import { ensureDir, writeFile, writeJSON } from '../fs-helpers.js';
 import { resolveConfig } from '../config.js';
 import { getDiffFiles } from '../git-diff.js';
@@ -47,8 +46,9 @@ export async function runScanCommand(options: ScanCommandOptions): Promise<void>
   });
 
   await ensureDir(outputDir);
-  const markdownReport = createMarkdownReport(report);
-  await writeFile(path.join(outputDir, 'report.json'), createJsonReport(report));
+  const markdownReport = formatReport(report, { format: 'md' });
+  const jsonReport = formatReport(report, { format: 'json' });
+  await writeFile(path.join(outputDir, 'report.json'), jsonReport);
   await writeFile(path.join(outputDir, 'report.md'), markdownReport);
   await writeJSON(path.join(outputDir, 'meta.json'), {
     cliVersion: report.meta.cliVersion,

--- a/packages/cli/src/core/formats/format-json.ts
+++ b/packages/cli/src/core/formats/format-json.ts
@@ -1,0 +1,5 @@
+import type { Report } from '../analyze.js';
+
+export function formatJson(report: Report): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/packages/cli/src/core/formats/format-md.ts
+++ b/packages/cli/src/core/formats/format-md.ts
@@ -1,0 +1,55 @@
+import type { Report } from '../analyze.js';
+
+export function formatMarkdown(report: Report): string {
+  const lines: string[] = [];
+  lines.push('<!-- base-lint-sticky -->');
+  lines.push('## Base Lint Report');
+  lines.push('');
+  const status = `**Status:** ${formatStatus(report.summary)}`;
+  lines.push(status);
+  lines.push('');
+  lines.push('| File | Line | Feature | Baseline | Guidance |');
+  lines.push('|------|------|---------|----------|----------|');
+  if (report.findings.length === 0) {
+    lines.push('| (none) | - | - | - | Baseline clear |');
+  } else {
+    for (const finding of report.findings) {
+      const line = finding.line != null ? String(finding.line) : '-';
+      const feature = escapePipes(finding.featureName);
+      const guidance = escapePipes(finding.guidance);
+      lines.push(`| ${finding.file} | ${line} | ${feature} | ${capitalize(finding.baseline)} | ${guidance} |`);
+    }
+  }
+  lines.push('');
+  lines.push(`Policy: Limited = error (max 0), Newly = ${formatNewlyPolicy(report.meta.treatNewlyAs)}`);
+  lines.push(`Dataset: web-features ${report.meta.datasetVersion}`);
+  return lines.join('\n');
+}
+
+function formatStatus(summary: Report['summary']): string {
+  const parts = [
+    `❌ Limited: ${summary.limited}`,
+    `⚠️ Newly: ${summary.newly}`,
+    `✅ Widely: ${summary.widely}`,
+  ];
+  return parts.join(' · ');
+}
+
+function formatNewlyPolicy(treat: Report['meta']['treatNewlyAs']): string {
+  switch (treat) {
+    case 'error':
+      return 'error';
+    case 'ignore':
+      return 'ignored';
+    default:
+      return 'warn (non-blocking)';
+  }
+}
+
+function escapePipes(value: string): string {
+  return value.replace(/\|/g, '\\|');
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/packages/cli/src/core/formats/format-sarif.ts
+++ b/packages/cli/src/core/formats/format-sarif.ts
@@ -1,0 +1,5 @@
+import type { Report } from '../analyze.js';
+
+export function formatSarif(_report: Report): string {
+  throw new Error('SARIF formatting is not yet implemented.');
+}

--- a/packages/cli/src/core/formats/index.ts
+++ b/packages/cli/src/core/formats/index.ts
@@ -1,0 +1,28 @@
+import type { Report } from '../analyze.js';
+import { formatJson } from './format-json.js';
+import { formatMarkdown } from './format-md.js';
+import { formatSarif } from './format-sarif.js';
+
+export type ReportFormat = 'md' | 'json' | 'sarif';
+
+const FORMATTERS: Record<ReportFormat, (report: Report) => string> = {
+  md: formatMarkdown,
+  json: formatJson,
+  sarif: formatSarif,
+};
+
+interface FormatReportOptions {
+  format: ReportFormat;
+}
+
+export function formatReport(report: Report, options: FormatReportOptions): string {
+  const formatter = FORMATTERS[options.format];
+  if (!formatter) {
+    throw new Error(`Unsupported report format: ${options.format}`);
+  }
+  return formatter(report);
+}
+
+export { formatJson } from './format-json.js';
+export { formatMarkdown } from './format-md.js';
+export { formatSarif } from './format-sarif.js';

--- a/packages/cli/src/core/reporters/json.ts
+++ b/packages/cli/src/core/reporters/json.ts
@@ -1,5 +1,6 @@
 import type { Report } from '../analyze.js';
+import { formatJson } from '../formats/format-json.js';
 
 export function createJsonReport(report: Report): string {
-  return JSON.stringify(report, null, 2);
+  return formatJson(report);
 }

--- a/packages/cli/src/core/reporters/markdown.ts
+++ b/packages/cli/src/core/reporters/markdown.ts
@@ -1,55 +1,6 @@
 import type { Report } from '../analyze.js';
+import { formatMarkdown } from '../formats/format-md.js';
 
 export function createMarkdownReport(report: Report): string {
-  const lines: string[] = [];
-  lines.push('<!-- base-lint-sticky -->');
-  lines.push('## Base Lint Report');
-  lines.push('');
-  const status = `**Status:** ${formatStatus(report.summary)}`;
-  lines.push(status);
-  lines.push('');
-  lines.push('| File | Line | Feature | Baseline | Guidance |');
-  lines.push('|------|------|---------|----------|----------|');
-  if (report.findings.length === 0) {
-    lines.push('| (none) | - | - | - | Baseline clear |');
-  } else {
-    for (const finding of report.findings) {
-      const line = finding.line != null ? String(finding.line) : '-';
-      const feature = escapePipes(finding.featureName);
-      const guidance = escapePipes(finding.guidance);
-      lines.push(`| ${finding.file} | ${line} | ${feature} | ${capitalize(finding.baseline)} | ${guidance} |`);
-    }
-  }
-  lines.push('');
-  lines.push(`Policy: Limited = error (max 0), Newly = ${formatNewlyPolicy(report.meta.treatNewlyAs)}`);
-  lines.push(`Dataset: web-features ${report.meta.datasetVersion}`);
-  return lines.join('\n');
-}
-
-function formatStatus(summary: Report['summary']): string {
-  const parts = [
-    `❌ Limited: ${summary.limited}`,
-    `⚠️ Newly: ${summary.newly}`,
-    `✅ Widely: ${summary.widely}`,
-  ];
-  return parts.join(' · ');
-}
-
-function formatNewlyPolicy(treat: Report['meta']['treatNewlyAs']): string {
-  switch (treat) {
-    case 'error':
-      return 'error';
-    case 'ignore':
-      return 'ignored';
-    default:
-      return 'warn (non-blocking)';
-  }
-}
-
-function escapePipes(value: string): string {
-  return value.replace(/\|/g, '\\|');
-}
-
-function capitalize(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
+  return formatMarkdown(report);
 }


### PR DESCRIPTION
## Summary
- add a core/formats registry with markdown, json, and sarif formatter entries
- update scan command to route report generation through the registry
- keep legacy reporter helpers delegating to the new formatter implementations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc40ff7bd08323934fd5d36721b769