### PR TITLE
feat(cli): add flexible scan output formats

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,13 +19,18 @@ program
   .description('Scan files for Baseline coverage issues')
   .option('--mode <mode>', 'analysis mode: diff or repo', 'diff')
   .option('--out <dir>', 'output directory for reports', DEFAULT_REPORT_DIRECTORY)
+  .option('--out-format <format>', 'format of stdout/file output: md|json|sarif', 'md')
+  .option('--out-file <file>', 'path to write the formatted report output')
   .option('--strict', 'enable strict feature detection')
   .option('--treat-newly <behavior>', 'treat Newly features as warn|error|ignore', 'warn')
   .option('--config <path>', 'path to config file override')
   .option('--print-full-report', 'print the full Markdown report to stdout')
-  .action(async (options) => {
+  .action(async (options, command) => {
     try {
-      await runScanCommand(options);
+      await runScanCommand({
+        ...options,
+        outFormatSource: command.getOptionValueSource('out-format'),
+      });
     } catch (error) {
       handleError(error);
     }


### PR DESCRIPTION
## Summary
- add CLI flags to configure scan output format and destination file
- extend scan command to emit canonical reports and write requested format to stdout or file
- keep markdown summary printing when using the default formatter and surface helpful errors for invalid formats

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc4bf51cc48323ad693efe8036d0c8