### PR TITLE
Centralize CLI policy exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Prefer setting defaults once? Configure them in [`base-lint.config.json`](#confi
 
 #### Exit codes
 
-`base-lint scan` and `base-lint enforce` share policy evaluation so CI can react consistently. Exit codes map to your Baseline
-thresholds:
+`base-lint scan` and `base-lint enforce` share the same policy helper so CI can react consistently. When a policy fails the CLI
+prints a short explanation and sets a non-zero exit code that maps directly to your Baseline thresholds:
 
 | Code | Meaning | Policy source |
 | --- | --- | --- |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -137,7 +137,7 @@ Prefer to change these defaults globally? See [Configuration](#configuration).
 
 #### Exit codes
 
-`scan` and `enforce` share the same policy helper so automation can key off the exit code:
+`scan` and `enforce` share the same policy helper so automation can key off the exit code. When a policy fails the CLI prints a short explanation and sets a non-zero exit code that maps directly to your Baseline thresholds:
 
 | Code | Meaning | Policy source |
 | --- | --- | --- |

--- a/packages/cli/src/core/policy/exit-codes.ts
+++ b/packages/cli/src/core/policy/exit-codes.ts
@@ -2,8 +2,8 @@ import type { ReportSummary } from '../analyze.js';
 import type { TreatNewlyAs } from '../../config.js';
 
 export interface PolicyThresholds {
-  maxLimited: number;
-  treatNewlyAs: TreatNewlyAs;
+  maxLimited?: number | null;
+  treatNewlyAs?: TreatNewlyAs;
 }
 
 export interface PolicyExit {
@@ -12,7 +12,7 @@ export interface PolicyExit {
 }
 
 export function evaluatePolicyExit(summary: ReportSummary, thresholds: PolicyThresholds): PolicyExit {
-  const maxLimited = Number.isFinite(thresholds.maxLimited) ? thresholds.maxLimited : 0;
+  const maxLimited = Number.isFinite(thresholds.maxLimited ?? 0) ? thresholds.maxLimited ?? 0 : 0;
 
   if (summary.limited > maxLimited) {
     return {
@@ -21,7 +21,7 @@ export function evaluatePolicyExit(summary: ReportSummary, thresholds: PolicyThr
     };
   }
 
-  if (thresholds.treatNewlyAs === 'error' && summary.newly > 0) {
+  if ((thresholds.treatNewlyAs ?? 'warn') === 'error' && summary.newly > 0) {
     return {
       code: 2,
       message: `Newly findings (${summary.newly}) are treated as errors by policy.`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,7 +97,10 @@ program.parseAsync().catch((error) => {
 });
 
 function handleError(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
-  logger.error(message);
+  if (error instanceof Error) {
+    logger.error(error.stack ?? error.message);
+  } else {
+    logger.error(String(error));
+  }
   process.exitCode = 3;
 }


### PR DESCRIPTION
## Summary
- relax the policy exit helper to handle optional thresholds and return consistent messaging for scan/enforce
- ensure CLI commands surface policy failures via exit codes while the global handler logs unexpected errors
- document the shared exit code contract in the top-level and CLI READMEs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc816a85688323b745e4abbe1051e9