### PR TITLE
feat(cli): add init scaffolding command

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,78 @@
+import path from 'path';
+import { DEFAULT_IGNORE } from '../config.js';
+import { logger } from '../logger.js';
+import { writeFileIfAbsent } from '../fs-helpers.js';
+import actionPkg from '../../action/package.json' with { type: 'json' };
+
+interface InitCommandOptions {
+  force?: boolean;
+}
+
+const DEFAULT_CONFIG_CONTENT = `${JSON.stringify(
+  {
+    mode: 'diff',
+    treatNewlyAs: 'warn',
+    maxLimited: 0,
+    strict: false,
+    targets: 'all',
+    suppress: [],
+    include: [],
+    ignore: [],
+  },
+  null,
+  2
+)}\n`;
+
+const DEFAULT_IGNORE_CONTENT = `${DEFAULT_IGNORE.join('\n')}\n`;
+
+function createWorkflowContent(actionVersion: string): string {
+  return `name: Base Lint\n\non:\n  pull_request:\n\npermissions:\n  contents: read\n  pull-requests: write\n  checks: write\n\njobs:\n  base-lint:\n    runs-on: ubuntu-latest\n    steps:\n      - name: Check out repository\n        uses: actions/checkout@v4\n        with:\n          fetch-depth: 0\n      - name: Run base-lint scan\n        run: npx --yes base-lint scan --out-format md --out-file base-lint-report.md\n      - name: Upload base-lint report\n        uses: actions/upload-artifact@v4\n        with:\n          name: base-lint-report\n          path: base-lint-report.md\n      - name: Publish base-lint feedback\n        uses: ej-sanmartin/base-lint@${actionVersion}\n        with:\n          github-token: \${{ secrets.GITHUB_TOKEN }}\n`;
+}
+
+export async function runInitCommand(options: InitCommandOptions = {}): Promise<void> {
+  const cwd = process.cwd();
+  const force = Boolean(options.force);
+  const actionVersion = `base-lint-action-v${actionPkg.version ?? '1.0.0'}`;
+
+  const targets = [
+    {
+      path: path.join(cwd, 'base-lint.config.json'),
+      contents: DEFAULT_CONFIG_CONTENT,
+    },
+    {
+      path: path.join(cwd, '.base-lintignore'),
+      contents: DEFAULT_IGNORE_CONTENT,
+    },
+    {
+      path: path.join(cwd, '.github', 'workflows', 'base-lint.yml'),
+      contents: createWorkflowContent(actionVersion),
+    },
+  ];
+
+  const results: { filePath: string; status: 'created' | 'overwritten' | 'skipped' }[] = [];
+
+  for (const target of targets) {
+    const status = await writeFileIfAbsent(target.path, target.contents, { force });
+    results.push({ filePath: target.path, status });
+    const relative = path.relative(cwd, target.path);
+    if (status === 'created') {
+      logger.info(`Created ${relative}`);
+    } else if (status === 'overwritten') {
+      logger.info(`Overwrote ${relative}`);
+    } else {
+      logger.warn(`Skipped ${relative} (already exists). Use --force to overwrite.`);
+    }
+  }
+
+  const generated = results.filter((result) => result.status !== 'skipped');
+
+  if (generated.length > 0) {
+    logger.info('Base Lint initialization complete!');
+    logger.info('Next steps:');
+    logger.info('  1. Review base-lint.config.json to customize thresholds.');
+    logger.info('  2. Commit the generated files to version control.');
+    logger.info('  3. Push to GitHub to enable the Base Lint workflow.');
+  } else {
+    logger.warn('No files were created. Re-run with --force to overwrite existing files.');
+  }
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -34,7 +34,7 @@ const DEFAULT_CONFIG: BaseLintConfig = {
   ignore: [],
 };
 
-const DEFAULT_IGNORE = ['node_modules/', 'dist/', 'build/', 'coverage/', '*.min.js'];
+export const DEFAULT_IGNORE = ['node_modules/', 'dist/', 'build/', 'coverage/', '*.min.js'];
 
 export async function resolveConfig(
   cwd: string,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import { runEnforceCommand } from './commands/enforce.js';
 import { runCommentCommand } from './commands/comment.js';
 import { runAnnotateCommand } from './commands/annotate.js';
 import { runCleanCommand } from './commands/clean.js';
+import { runInitCommand } from './commands/init.js';
 import { DEFAULT_REPORT_DIRECTORY, DEFAULT_REPORT_PATH } from './constants.js';
 import { logger } from './logger.js';
 import pkg from '../package.json' with { type: 'json' };
@@ -14,6 +15,18 @@ program
   .name('base-lint')
   .description('Baseline-aware linting for modern web platform features')
   .version(pkg.version ?? '0.0.0');
+
+program
+  .command('init')
+  .description('Generate base-lint config, ignore file, and GitHub workflow scaffolding')
+  .option('--force', 'overwrite existing files')
+  .action(async (options) => {
+    try {
+      await runInitCommand(options);
+    } catch (error) {
+      handleError(error);
+    }
+  });
 
 program
   .command('scan')


### PR DESCRIPTION
## Summary
- add an `init` CLI command that scaffolds the config, ignore list, and GitHub workflow with an optional `--force` flag
- expose default ignore patterns and a reusable write helper for initialization logic
- expand filesystem helper tests to cover the new helper APIs

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dc8277b37483239b8ecac3c3e2e6c0