### PR TITLE
docs: format field reference as table

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,16 @@ Create an optional `base-lint.config.json` at the repository root:
 
 Field reference:
 
-- **`mode`** (default: `"diff"`) – Choose between scanning only the current Git diff (`"diff"`) or the entire repository (`"repo"`). Diff mode keeps pull requests focused on new changes, while repo mode is ideal for scheduled audits and initial migrations.
-- **`treatNewlyAs`** (default: `"warn"`) – Decide how Newly Baseline findings behave. Use `"warn"` to surface them without breaking CI, `"error"` to fail builds that introduce Newly features, or `"ignore"` to silence them entirely when you only care about Limited gaps.
-- **`maxLimited`** (default: `0`) – Set the number of Limited findings tolerated by `base-lint enforce`. Raising the threshold lets teams roll out Base Lint gradually while they pay down existing debt.
-- **`strict`** (default: `false`) – Enable stricter feature detection heuristics, such as reporting computed property access. Turn this on when you want the most defensive signal, or leave it off to reduce noise from dynamic code.
-- **`targets`** (default: `"all"`) – Reserved for future Baseline targeting controls. Keep the default unless you are experimenting with internal builds that scope analysis to a specific audience.
-- **`suppress`** (default: `[]`) – Provide Baseline feature IDs to mute when you have hand-reviewed fallbacks or intentionally accepted risk (for example, suppressing `has` after documenting a polyfill strategy).
-- **`include`** (default: `[]`) – Supply glob patterns that act as an allowlist. Leave empty to scan everything the mode selects, or narrow the scan to specific folders (e.g., `"src/**/*"`) when only part of the repo should be linted.
-- **`ignore`** (default: `[]`) – Add project-wide ignore patterns that apply to every invocation. These values augment Base Lint’s built-in defaults and any `.base-lintignore` entries.
+| Field | Default | Description |
+|-------|---------|-------------|
+| `mode` | `"diff"` | Choose between scanning only the current Git diff (`"diff"`) or the entire repository (`"repo"`). Diff mode keeps pull requests focused on new changes, while repo mode is ideal for scheduled audits and initial migrations. |
+| `treatNewlyAs` | `"warn"` | Decide how Newly Baseline findings behave. Use `"warn"` to surface them without breaking CI, `"error"` to fail builds that introduce Newly features, or `"ignore"` to silence them entirely when you only care about Limited gaps. |
+| `maxLimited` | `0` | Set the number of Limited findings tolerated by `base-lint enforce`. Raising the threshold lets teams roll out Base Lint gradually while they pay down existing debt. |
+| `strict` | `false` | Enable stricter feature detection heuristics, such as reporting computed property access. Turn this on when you want the most defensive signal, or leave it off to reduce noise from dynamic code. |
+| `targets` | `"all"` | Reserved for future Baseline targeting controls. Keep the default unless you are experimenting with internal builds that scope analysis to a specific audience. |
+| `suppress` | `[]` | Provide Baseline feature IDs to mute when you have hand-reviewed fallbacks or intentionally accepted risk (for example, suppressing `has` after documenting a polyfill strategy). |
+| `include` | `[]` | Supply glob patterns that act as an allowlist. Leave empty to scan everything the mode selects, or narrow the scan to specific folders (e.g., `"src/**/*"`) when only part of the repo should be linted. |
+| `ignore` | `[]` | Add project-wide ignore patterns that apply to every invocation. These values augment Base Lint’s built-in defaults and any `.base-lintignore` entries. |
 
 Ignore additional paths by creating `.base-lintignore` (same format as `.gitignore`). Base Lint always starts with its built-in defaults and then appends the config and ignore-file entries when assembling the matcher (see [`packages/cli/src/config.ts`](packages/cli/src/config.ts)). Default ignore entries:
 


### PR DESCRIPTION
## Summary
- convert the README field reference section into a markdown table for quicker scanning of options

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dc956f81a48323adbcf1c7475a5882