### PR TITLE
Add optional npm caching to Base Lint action

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ jobs:
           treat-newly-as: warn
           comment: true
           checks: true
+          cache: true
 ```
 
 Diff mode needs the base commit to be present locally, so configure `actions/checkout` with `fetch-depth: 0` (or switch Base Lint to `mode: repo`) to avoid fetching only the latest commit. Without the deeper history, Base Lint falls back to scanning nothing and reports “No files matched the scan configuration.”
+
+Enabling `cache: true` reuses the npm directories Base Lint touches on every run (`~/.npm/_cacache` and `~/.npm/_npx`). The
+action automatically derives a cache key from the bundled CLI version (`base-lint-cli-${version}`) so new releases invalidate
+old entries. Override the key with `cache-key` when you need to segment caches (for example, by operating system), but include
+the CLI version in the string to keep release upgrades busting stale data.
 
 The GitHub Action metadata now lives at the repository root in [`action.yml`](./action.yml) while the compiled bundle continues
 to ship from [`packages/action/dist`](packages/action/dist). Build and commit the bundle whenever you update the TypeScript

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
   checks:
     description: 'Publish GitHub check annotations'
     default: 'true'
+  cache:
+    description: 'Cache npm artifacts between runs to speed up base-lint invocations'
+    default: 'false'
+  cache-key:
+    description: 'Override the cache key (defaults to base-lint-cli-${version})'
 runs:
   using: 'node20'
   main: 'packages/action/dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2971,7 +2971,8 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",
-        "@actions/github": "^6.0.1"
+        "@actions/github": "^6.0.1",
+        "@actions/cache": "^3.2.4"
       },
       "devDependencies": {
         "typescript": "^5.4.2"

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -13,10 +13,19 @@ GitHub Action wrapper for the `base-lint` CLI. See [`packages/cli`](../cli) for 
     treat-newly-as: warn
     comment: true
     checks: true
+    cache: true
 ```
 
 The action manifest exposed to users lives at the repository root (`../../action.yml`) and re-exports the bundle built from this
 workspace's sources.
+
+### Caching
+
+Set `cache: true` to reuse the npm directories Base Lint warms up on every run (`~/.npm/_cacache` and `~/.npm/_npx`). By default
+the action derives a cache key from the bundled CLI version (`base-lint-cli-${version}`), ensuring that publishing a new action
+release also busts stale caches. Override the key with `cache-key` when you need repo-specific segmentation (for example,
+appending the operating system or lockfile hash), but keep the CLI version in the string so future releases continue to
+invalidate old entries automatically. When `cache` is `false` or no key can be resolved, caching is skipped entirely.
 
 ## Release checklist
 

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -20,6 +20,11 @@ inputs:
   checks:
     description: 'Publish GitHub check annotations'
     default: 'true'
+  cache:
+    description: 'Cache npm artifacts between runs to speed up base-lint invocations'
+    default: 'false'
+  cache-key:
+    description: 'Override the cache key (defaults to base-lint-cli-${version})'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -33,6 +33,7 @@ __export(index_exports, {
   runBaseLint: () => runBaseLint
 });
 module.exports = __toCommonJS(index_exports);
+var cache = __toESM(require("@actions/cache"));
 
 // virtual:@actions/core
 var core_exports = {};
@@ -119,8 +120,95 @@ var context = {
 var import_child_process = require("child_process");
 var import_path = __toESM(require("path"));
 var import_url = require("url");
+
+// ../cli/package.json
+var package_default = {
+  name: "base-lint",
+  version: "1.1.2",
+  description: "Lint your repo against Web Baseline policies",
+  license: "MIT",
+  bugs: {
+    url: "https://github.com/ej-sanmartin/base-lint/issues"
+  },
+  homepage: "https://github.com/web-baseline/base-lint#readme",
+  repository: {
+    type: "git",
+    url: "https://github.com/ej-sanmartin/base-lint",
+    directory: "packages/cli"
+  },
+  funding: {
+    type: "individual",
+    url: "https://Ko-fi.com/esanmartin"
+  },
+  type: "module",
+  bin: {
+    "base-lint": "dist/index.js"
+  },
+  files: [
+    "dist"
+  ],
+  imports: {
+    vitest: "../../tests/mocks/vitest.js"
+  },
+  scripts: {
+    build: "tsup --config tsup.config.ts",
+    dev: "tsx src/index.ts --help",
+    prepublishOnly: "npm run build"
+  },
+  dependencies: {
+    "@typescript-eslint/typescript-estree": "^6.21.0",
+    commander: "^11.1.0",
+    globby: "^13.2.2",
+    ignore: "^5.3.1",
+    minimatch: "^9.0.3",
+    "node-html-parser": "^6.1.11",
+    picocolors: "^1.0.0",
+    postcss: "^8.4.35",
+    "web-features": "^2.0.0"
+  },
+  devDependencies: {
+    "@types/node": "^20.11.30",
+    tsup: "^8.0.1",
+    tsx: "^4.7.1",
+    typescript: "^5.4.2"
+  },
+  keywords: [
+    "lint",
+    "baseline",
+    "eslint",
+    "stylelint",
+    "typescript",
+    "javascript",
+    "css",
+    "cli",
+    "ci",
+    "bot",
+    "static-analysis",
+    "code-quality",
+    "code-style",
+    "automation",
+    "best-practices"
+  ]
+};
+
+// src/index.ts
 var import_meta = {};
 var missingTokenWarningIssued = false;
+var BUNDLED_CLI_VERSION = package_default.version ?? "";
+var DEFAULT_CACHE_KEY = BUNDLED_CLI_VERSION ? `base-lint-cli-${BUNDLED_CLI_VERSION}` : void 0;
+function resolveCachePaths() {
+  const homeDir = process.env.HOME ?? process.env.USERPROFILE;
+  if (!homeDir) {
+    return [];
+  }
+  return [import_path.default.join(homeDir, ".npm", "_cacache"), import_path.default.join(homeDir, ".npm", "_npx")];
+}
+function resolveCacheKey(inputKey) {
+  if (inputKey) {
+    return inputKey;
+  }
+  return DEFAULT_CACHE_KEY;
+}
 function resolveGithubToken() {
   const inputToken = getInput("github-token");
   const envToken = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
@@ -140,6 +228,34 @@ async function main() {
     const treatNewlyAs = getInput("treat-newly-as") || "warn";
     const shouldComment = getBooleanInput("comment");
     const shouldAnnotate = getBooleanInput("checks");
+    const shouldCache = getBooleanInput("cache");
+    const cacheKeyInput = getInput("cache-key");
+    const resolvedCacheKey = resolveCacheKey(cacheKeyInput || void 0);
+    const cachePaths = resolveCachePaths();
+    const cacheFeatureAvailable = typeof cache.isFeatureAvailable === "function" ? cache.isFeatureAvailable() : false;
+    const cachingEnabled = Boolean(
+      shouldCache && resolvedCacheKey && cachePaths.length > 0 && cacheFeatureAvailable
+    );
+    if (shouldCache && !resolvedCacheKey) {
+      info("Caching requested but no cache key resolved. Skipping restore.");
+    } else if (shouldCache && cachePaths.length === 0) {
+      info("Caching requested but no cache paths resolved. Skipping restore.");
+    } else if (shouldCache && !cacheFeatureAvailable) {
+      info("Caching requested but the feature is unavailable on this runner. Skipping restore.");
+    }
+    let restoredCacheKey;
+    if (cachingEnabled) {
+      try {
+        restoredCacheKey = await cache.restoreCache(cachePaths, resolvedCacheKey);
+        if (restoredCacheKey) {
+          info(`Restored npm cache with key ${restoredCacheKey}.`);
+        } else {
+          info(`No npm cache found for key ${resolvedCacheKey}.`);
+        }
+      } catch (error2) {
+        warning(`Failed to restore npm cache: ${error2.message}`);
+      }
+    }
     const reportDir = ".base-lint-report";
     const reportJson = import_path.default.join(reportDir, "report.json");
     const reportMd = import_path.default.join(reportDir, "report.md");
@@ -181,6 +297,20 @@ async function main() {
     }
     if (enforcementFailed) {
       setFailed("Baseline policy violated. See report for details.");
+    }
+    if (cachingEnabled && !restoredCacheKey) {
+      try {
+        await cache.saveCache(cachePaths, resolvedCacheKey);
+        info(`Saved npm cache with key ${resolvedCacheKey}.`);
+      } catch (error2) {
+        if (error2 instanceof cache.ReserveCacheError || error2 instanceof cache.ValidationError) {
+          info(`Skipping cache save: ${error2.message}`);
+        } else if (error2.message?.includes("Cache already exists")) {
+          info(`Skipping cache save: ${error2.message}`);
+        } else {
+          warning(`Failed to save npm cache: ${error2.message}`);
+        }
+      }
     }
   } catch (error2) {
     setFailed(error2.message);

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@actions/github": "^6.0.1"
+    "@actions/github": "^6.0.1",
+    "@actions/cache": "^3.2.4"
   },
   "devDependencies": {
     "typescript": "^5.4.2"

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -1,8 +1,10 @@
+import * as cache from '@actions/cache';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { spawn } from 'child_process';
 import path from 'path';
 import { pathToFileURL } from 'url';
+import baseLintPackageJson from '../../cli/package.json' assert { type: 'json' };
 
 type RunBaseLintDeps = {
   core?: Pick<typeof core, 'info'>;
@@ -10,6 +12,26 @@ type RunBaseLintDeps = {
 };
 
 let missingTokenWarningIssued = false;
+
+const BUNDLED_CLI_VERSION = (baseLintPackageJson as { version?: string }).version ?? '';
+const DEFAULT_CACHE_KEY = BUNDLED_CLI_VERSION ? `base-lint-cli-${BUNDLED_CLI_VERSION}` : undefined;
+
+function resolveCachePaths(): string[] {
+  const homeDir = process.env.HOME ?? process.env.USERPROFILE;
+  if (!homeDir) {
+    return [];
+  }
+
+  return [path.join(homeDir, '.npm', '_cacache'), path.join(homeDir, '.npm', '_npx')];
+}
+
+function resolveCacheKey(inputKey: string | undefined): string | undefined {
+  if (inputKey) {
+    return inputKey;
+  }
+
+  return DEFAULT_CACHE_KEY;
+}
 
 function resolveGithubToken(): string | undefined {
   const inputToken = core.getInput('github-token');
@@ -33,6 +55,39 @@ async function main(): Promise<void> {
     const treatNewlyAs = core.getInput('treat-newly-as') || 'warn';
     const shouldComment = core.getBooleanInput('comment');
     const shouldAnnotate = core.getBooleanInput('checks');
+    const shouldCache = core.getBooleanInput('cache');
+    const cacheKeyInput = core.getInput('cache-key');
+    const resolvedCacheKey = resolveCacheKey(cacheKeyInput || undefined);
+    const cachePaths = resolveCachePaths();
+
+    const cacheFeatureAvailable =
+      typeof cache.isFeatureAvailable === 'function' ? cache.isFeatureAvailable() : false;
+    const cachingEnabled = Boolean(
+      shouldCache && resolvedCacheKey && cachePaths.length > 0 && cacheFeatureAvailable
+    );
+
+    if (shouldCache && !resolvedCacheKey) {
+      core.info('Caching requested but no cache key resolved. Skipping restore.');
+    } else if (shouldCache && cachePaths.length === 0) {
+      core.info('Caching requested but no cache paths resolved. Skipping restore.');
+    } else if (shouldCache && !cacheFeatureAvailable) {
+      core.info('Caching requested but the feature is unavailable on this runner. Skipping restore.');
+    }
+
+    let restoredCacheKey: string | undefined;
+
+    if (cachingEnabled) {
+      try {
+        restoredCacheKey = await cache.restoreCache(cachePaths, resolvedCacheKey!);
+        if (restoredCacheKey) {
+          core.info(`Restored npm cache with key ${restoredCacheKey}.`);
+        } else {
+          core.info(`No npm cache found for key ${resolvedCacheKey}.`);
+        }
+      } catch (error) {
+        core.warning(`Failed to restore npm cache: ${(error as Error).message}`);
+      }
+    }
 
     const reportDir = '.base-lint-report';
     const reportJson = path.join(reportDir, 'report.json');
@@ -81,6 +136,21 @@ async function main(): Promise<void> {
 
     if (enforcementFailed) {
       core.setFailed('Baseline policy violated. See report for details.');
+    }
+
+    if (cachingEnabled && !restoredCacheKey) {
+      try {
+        await cache.saveCache(cachePaths, resolvedCacheKey!);
+        core.info(`Saved npm cache with key ${resolvedCacheKey}.`);
+      } catch (error) {
+        if (error instanceof cache.ReserveCacheError || error instanceof cache.ValidationError) {
+          core.info(`Skipping cache save: ${(error as Error).message}`);
+        } else if ((error as Error).message?.includes('Cache already exists')) {
+          core.info(`Skipping cache save: ${(error as Error).message}`);
+        } else {
+          core.warning(`Failed to save npm cache: ${(error as Error).message}`);
+        }
+      }
     }
   } catch (error) {
     core.setFailed((error as Error).message);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -26,7 +26,7 @@ const DEFAULT_CONFIG_CONTENT = `${JSON.stringify(
 const DEFAULT_IGNORE_CONTENT = `${DEFAULT_IGNORE.join('\n')}\n`;
 
 function createWorkflowContent(actionVersion: string): string {
-  return `name: Base Lint\n\non:\n  pull_request:\n\npermissions:\n  contents: read\n  pull-requests: write\n  checks: write\n\njobs:\n  baseline:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          fetch-depth: 0\n      - uses: ej-sanmartin/base-lint@base-lint-action-v${actionVersion}\n        with:\n          github-token: \${{ github.token }}\n          mode: diff\n          max-limited: 0\n          treat-newly-as: warn\n          comment: true\n          checks: true\n`;
+  return `name: Base Lint\n\non:\n  pull_request:\n\npermissions:\n  contents: read\n  pull-requests: write\n  checks: write\n\njobs:\n  baseline:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          fetch-depth: 0\n      - uses: ej-sanmartin/base-lint@base-lint-action-v${actionVersion}\n        with:\n          github-token: \${{ github.token }}\n          mode: diff\n          max-limited: 0\n          treat-newly-as: warn\n          comment: true\n          checks: true\n          cache: true\n`;
 }
 
 export async function runInitCommand(options: InitCommandOptions = {}): Promise<void> {

--- a/scripts/build-action.mjs
+++ b/scripts/build-action.mjs
@@ -22,6 +22,7 @@ await build({
   target: ['node18'],
   outfile: path.join(distDir, 'index.js'),
   sourcemap: false,
+  external: ['@actions/cache'],
   plugins: [
     {
       name: 'virtual-actions-modules',

--- a/tests/mocks/@actions/cache.js
+++ b/tests/mocks/@actions/cache.js
@@ -1,0 +1,15 @@
+export function isFeatureAvailable() {
+  return true;
+}
+
+export async function restoreCache() {
+  return undefined;
+}
+
+export async function saveCache() {
+  return undefined;
+}
+
+export class ReserveCacheError extends Error {}
+
+export class ValidationError extends Error {}


### PR DESCRIPTION
## Summary
- expose `cache` and `cache-key` inputs in the action manifests and update the README guidance
- wire the action runtime into `@actions/cache` so npm directories restore/save with a CLI-version-based default key
- refresh the bundled output, CLI init workflow template, build script, and tests to support the new caching flow

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dedb8675fc832380663b52e0611d1a